### PR TITLE
Add basic Windows support

### DIFF
--- a/pytograph
+++ b/pytograph
@@ -23,6 +23,8 @@ logging.basicConfig(format=logFormat)
 logger = logging.getLogger('pytograph')
 logger.setLevel(logging.INFO)
 
+IS_WIN = sys.platform.startswith('win')
+
 class PytoWatchdogHandler(PatternMatchingEventHandler):
   """
   Watchdog event handler.
@@ -72,9 +74,9 @@ class RemoteControl:
   # canonical path on the remote filesystem.
   def get_remote_path(self, local_path):
     # Strip the local base path from the local full canonical path to get the relative path
-    # TODO: This will not work properly on Windows since slash directions will conflict
-    remote_relative = local_path[self._local_base_length:]
-    return self._remote_base + remote_relative
+    remote_relative = local_path[self._local_base_length:].replace('\\', '/')
+    # For windows source reverse the slashes for correct copy to the posix destination
+    return self._remote_base + (remote_relative.replace('\\', '/') if IS_WIN else remote_relative)
 
   def transfer_file(self, src_path):
     dest_path = self.get_remote_path(src_path)
@@ -140,7 +142,11 @@ class SFTPConnection:
     # If we don't have a connection yet, attempt password authentication
     if self._connection is None:
       try:
-        self._connection = pysftp.Connection(host, port = port, username = username, password = password)
+        cnopts = pysftp.CnOpts()
+        if IS_WIN:
+          # On Windows ~/.ssh/known_hosts will not be found and would cause error
+          cnopts.hostkeys = None
+        self._connection = pysftp.Connection(host, port = port, username = username, password = password, cnopts = cnopts)
       except Exception as e:
         logger.error('Could not successfully connect to %s\nCause: %s' % (self._ssh_prefix, e))
         sys.exit(1)


### PR DESCRIPTION
Added minimal support for the script to run on Windows source. 
Tested on Win10 host with Python2.7 and RedHat-based target VM. File watching and synchronization appears to be working correctly.